### PR TITLE
Fixed bug where previous ID now has to be an int

### DIFF
--- a/terraform/modules/lambda/parameter-store.tf
+++ b/terraform/modules/lambda/parameter-store.tf
@@ -119,7 +119,7 @@ resource "aws_ssm_parameter" "previous_most_recent_rating_id" {
   name        = "/${var.application_name}/${var.environment}/previous-most-recent-rating-id"
   description = "The ID of the most recent rating ID encountered on the previous run of the lambda expression"
   type        = "String"
-  value       = "dummy"
+  value       = "-1"
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
In the source data from the endpoint, the IDs are ints rather than strings like they were in high-five-tracker. So we need to read this parameter as an int, which then throws an error for the value `dummy`. We use the `>` comparison to check our IDs, so we need a negative number to ensure that it succeeds for any ID value on the first run.