### PR TITLE
Fix retries

### DIFF
--- a/src/rate-mds.py
+++ b/src/rate-mds.py
@@ -79,7 +79,7 @@ def get_ratings_batch(session, page):
   response = session.get(url)
 
   if response.status_code != 200:
-    logger.error(f"Received status code {response.status_code} after {REQUEST_RETRIES} attempts from URL '{url}'")
+    logger.error(f"Received status code {response.status_code} after {NUM_RETRIES} attempts from URL '{url}'")
     sys.exit(-1)
 
   response_data = json.loads(response.text)
@@ -102,7 +102,7 @@ def get_all_ratings():
   session = requests.Session()
   session.mount("https://", adapter)
 
-  # This endpoint is a bit crazy. 
+  # This endpoint is a bit crazy.
 
   # First, requesting page 0 gives the last page, as does requesting every page > the last page
 

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -4,7 +4,7 @@ module "lambda" {
   environment             = var.environment
   region                  = var.region
   application_name        = var.application_name
-  
+
   num_days_to_keep_images = 30
 
   cron_expression         = "cron(0 16 * * ? *)"  # Run every day at 4:00 PM UTC = 9:00 AM PDT or 8:00 AM PST
@@ -25,8 +25,8 @@ module "lambda" {
   base_url                = "https://www.ratemds.com/doctor-ratings/dr-kathryn-louise-toews-new-westminster-bc-ca/?json=true"
 
   batch_size              = 1000
-  num_retries             = 3
-  retry_backoff_factor    = 0.5
+  num_retries             = 5
+  retry_backoff_factor    = 1 # Backoff time is backoff_factor * 2^retries
 }
 
 module "alarms" {


### PR DESCRIPTION
We've been getting alarms lately because of 2 things:

1. The endpoint is sometimes returning an error, despite retries
2. Typo in the log message indicating this error

This fixes number 2, and retunes the retry logic to be more forgiving to hopefully fix number 1

Changes have been deployed to prod

Fixes https://github.com/euan-forrester/rate-mds-tracker/issues/6
Fixes https://github.com/euan-forrester/rate-mds-tracker/issues/7