### PR TITLE
Don't call exit when finishing successfully

### DIFF
--- a/src/rate-mds.py
+++ b/src/rate-mds.py
@@ -214,7 +214,5 @@ def get_new_ratings_and_send_email(event, context):
   if SET_MOST_RECENT_RATING_ID and (len(all_ratings) > 0):
     config_helper.set("previous-most-recent-rating-id", str(all_ratings[0]['id']))
 
-  graceful_exit(0)
-
 if RUN_AT_SCRIPT_STARTUP:
   get_new_ratings_and_send_email(None, None)


### PR DESCRIPTION
I added this just because but it turns out that lambda doesn't like it and also it's an antipattern

Deployed to prod