### PR TITLE
Added ability to specify user agent for request to external API

### DIFF
--- a/src/config/config.ini
+++ b/src/config/config.ini
@@ -3,6 +3,7 @@
 aws-region=us-west-2
 
 base-url=https://www.ratemds.com/doctor-ratings/dr-kathryn-louise-toews-new-westminster-bc-ca/?json=true
+user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:142.0) Gecko/20100101 Firefox/142.0
 num-retries=3
 retry-backoff-factor=0.5
 
@@ -10,7 +11,7 @@ minimum-average-score=4
 
 run-at-script-startup=true
 
-previous-most-recent-rating-id=dummy
+previous-most-recent-rating-id=0
 set-most-recent-rating-id=true
 
 metrics-namespace=rate-mds-tracker-dev

--- a/src/rate-mds.py
+++ b/src/rate-mds.py
@@ -40,6 +40,7 @@ config_helper = ConfigHelper.get_config_helper(default_env_name="dev", applicati
 AWS_REGION              = config_helper.get("aws-region")
 
 BASE_URL                = config_helper.get("base-url")
+USER_AGENT              = config_helper.get("user-agent")
 NUM_RETRIES             = config_helper.getInt("num-retries")
 RETRY_BACKOFF_FACTOR    = config_helper.getFloat("retry-backoff-factor")
 
@@ -81,7 +82,11 @@ def get_ratings_batch(session, page):
   if page is not None:
     url += f"&page={page}"
 
-  response = session.get(url)
+  headers = {
+    'User-Agent': USER_AGENT
+  }
+
+  response = session.get(url, headers=headers)
 
   if response.status_code != 200:
     logger.error(f"Received status code {response.status_code} after {NUM_RETRIES} attempts from URL '{url}'")

--- a/terraform/modules/lambda/parameter-store.tf
+++ b/terraform/modules/lambda/parameter-store.tf
@@ -5,6 +5,13 @@ resource "aws_ssm_parameter" "base_url" {
   value       = var.base_url
 }
 
+resource "aws_ssm_parameter" "user_agent" {
+  name        = "/${var.application_name}/${var.environment}/user-agent"
+  description = "User agent to use when making request"
+  type        = "String"
+  value       = var.user_agent
+}
+
 resource "aws_ssm_parameter" "batch_size" {
   name        = "/${var.application_name}/${var.environment}/batch-size"
   description = "How many ratings to get in a single call"

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -40,6 +40,9 @@ variable "from_email" {
 variable "base_url" {
 }
 
+variable "user_agent" {
+}
+
 variable "batch_size" {
 }
 

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -23,6 +23,7 @@ module "lambda" {
   minimum_average_score   = var.minimum_average_score
 
   base_url                = "https://www.ratemds.com/doctor-ratings/dr-kathryn-louise-toews-new-westminster-bc-ca/?json=true"
+  user_agent              = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:142.0) Gecko/20100101 Firefox/142.0"
 
   batch_size              = 1000
   num_retries             = 5


### PR DESCRIPTION
Our API endpoint has been returning `403` forbidden lately when called from Python, and adding a user agent seems to resolve the issue

We'll have to keep an eye out to see if the arms race continues

Deployed to prod

Fixes https://github.com/euan-forrester/rate-mds-tracker/issues/11